### PR TITLE
Fix compile with glibc

### DIFF
--- a/FastNoiseSIMD.cpp
+++ b/FastNoiseSIMD.cpp
@@ -28,6 +28,7 @@
 
 #include "FastNoiseSIMD.h"
 #include <assert.h>
+#include <stdlib.h>
 
 #ifdef FN_COMPILE_NO_SIMD_FALLBACK
 #define SIMD_LEVEL_H FN_NO_SIMD_FALLBACK


### PR DESCRIPTION
Trying to compile on Ubuntu 16.04, I get an error that `free` hasn't been declared. Canonically, malloc and free are declared in stdlib.h, so I just added that include.
