### PR TITLE
Fix AVX512 on gcc/clang.

### DIFF
--- a/FastNoiseSIMD/FastNoiseSIMD_avx512.cpp
+++ b/FastNoiseSIMD/FastNoiseSIMD_avx512.cpp
@@ -42,7 +42,11 @@
 
 #define SIMD_LEVEL_H FN_AVX512
 #include "FastNoiseSIMD_internal.h"
+#ifdef _WIN32
 #include <intrin.h> //AVX512
+#else
+#include <x86intrin.h> //AVX512
+#endif
 
 #define SIMD_LEVEL FN_AVX512
 #include "FastNoiseSIMD_internal.cpp"


### PR DESCRIPTION
According to [these people here](https://stackoverflow.com/questions/11228855/header-files-for-x86-simd-intrinsics), `zmmintrin.h` is for AVX512 on gcc, but I can find neither it nor `intrin.h` on my system (with gcc 7.2.1). They also say that `x86intrin.h` works for gcc, clang, and icc, and I _can_ find that for both gcc and clang. It also seems to work with icc, though there are other issues there.