### PR TITLE
Update casts for NEON

### DIFF
--- a/FastNoiseSIMD/FastNoiseSIMD_internal.cpp
+++ b/FastNoiseSIMD/FastNoiseSIMD_internal.cpp
@@ -190,7 +190,9 @@ static SIMDf VECTORCALL FUNC(FLOOR)(SIMDf a)
 {
 	SIMDf fval = SIMDf_CONVERT_TO_FLOAT(SIMDi_CONVERT_TO_INT(a));
 
-	return vsubq_f32(fval, SIMDf_AND(SIMDf_LESS_THAN(a, fval), SIMDf_NUM(1)));
+	return vsubq_f32(fval,
+	                 SIMDf_CAST_TO_FLOAT(vandq_s32(SIMDf_LESS_THAN(a, fval),
+	                                               SIMDi_CAST_TO_INT(SIMDf_NUM(1)))));
 }
 #define SIMDf_FLOOR(a) FUNC(FLOOR)(a)
 #else
@@ -199,7 +201,7 @@ static SIMDf VECTORCALL FUNC(FLOOR)(SIMDf a)
 #endif
 
 #define SIMDf_ABS(a) vabsq_f32(a)
-#define SIMDf_BLENDV(a,b,mask) vbslq_f32( vreinterpretq_u32_s32(mask),b,a)
+#define SIMDf_BLENDV(a,b,mask) vbslq_f32(vreinterpretq_u32_s32(mask),b,a)
 
 #define SIMDi_ADD(a,b) vaddq_s32(a,b)
 #define SIMDi_SUB(a,b) vsubq_s32(a,b)


### PR DESCRIPTION
The problem is that the comparisons return `uint32x4_t` and `MASK` is `int32x4_t`; converting comparison results to float just causes an error trying to convert back to int. The second commit adds some other casts to make unsigned/signed explicit (and now works without `-flax-vector-conversions`).

This fixes the other problem in #23. Still not able to build on armv7 because it needs `android_getCpuFeatures` and `cpu-features.c` doesn't yet build.