### PR TITLE
Change ARM includes to work off Android.

### DIFF
--- a/FastNoiseSIMD/ARM/cpu-features.c
+++ b/FastNoiseSIMD/ARM/cpu-features.c
@@ -61,6 +61,7 @@
  * NDK r4: Initial release
  */
 
+#define _GNU_SOURCE
 #include "cpu-features.h"
 
 #include <dlfcn.h>
@@ -69,7 +70,8 @@
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <sys/system_properties.h>
+#include <string.h>
+#include <unistd.h>
 
 static  pthread_once_t     g_once;
 static  int                g_inited;


### PR DESCRIPTION
I don't see any use of system properties anywhere; `memmem` and `TEMP_FAILURE_RETRY` appear to be GNU extensions, so define `_GNU_SOURCE`.

I cannot test on Android, and unfortunately do not have access to an aarch64 machine (so I have to try a full package build later), but this does work on armv7hl now.